### PR TITLE
Read from stdin and reuse same window

### DIFF
--- a/inc/app.h
+++ b/inc/app.h
@@ -14,6 +14,8 @@ typedef struct app_ {
 
     unsigned deferred_count;
     char** deferred_files;
+
+    bool is_reading_stdin;
 } app_t;
 
 /*  Calls instance_run on every instance */

--- a/inc/base.h
+++ b/inc/base.h
@@ -15,6 +15,7 @@
 #include <assert.h>
 #include <ctype.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <math.h>
 #include <stdarg.h>
 #include <stdbool.h>
@@ -22,5 +23,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 #endif

--- a/inc/loader.h
+++ b/inc/loader.h
@@ -22,6 +22,7 @@ typedef enum loader_state_ {
     LOADER_ERROR_NO_FILE,
     LOADER_ERROR_BAD_ASCII_STL,
     LOADER_ERROR_WRONG_SIZE,
+    LOADER_ERROR_STDIN,
 } loader_state_t;
 
 typedef struct loader_ loader_t;

--- a/platform/linux.c
+++ b/platform/linux.c
@@ -9,7 +9,14 @@ static app_t* app_handle = NULL;
 void platform_init(app_t* app, int argc, char** argv) {
     app_handle = app;
     if (argc == 2) {
-        app_open(app, argv[1]);
+        // Defer loading stl from stdin. It has to happen in the main event loop
+        // to avoid creating new windows.
+        app->is_reading_stdin = !strcmp(argv[1], "-");
+        if (app->is_reading_stdin) {
+            app_defer_open(app, argv[1]);
+        } else {
+            app_open(app, argv[1]);
+        }
     }
     if (app->instance_count == 0) {
         //  Construct a dummy window, which triggers GLFW initialization

--- a/src/main.c
+++ b/src/main.c
@@ -16,6 +16,7 @@ int main(int argc, char** argv) {
         .draw_mode=DRAW_SHADED,
         .deferred_count=0,
         .deferred_files=NULL,
+        .is_reading_stdin=false,
     };
     app.theme = theme_new_solarized();
 


### PR DESCRIPTION
As it says, there's a need to be able to have erizo listen for models on a pipe, and load the new models as they come in. This is part of my plan to use erizo as part of my code CAD toolset with libfive and/or fidget. You've created awesome tools to work from so figured let's start here. :)

This feature creates a new simple pipe format for erizo. Users must pipe in the filesize as a textual number, a space, and then the binary of the stl. erizo will then check to see if there is a new filesize byte (the detection is not intelligent as you'll see) constantly. On a new model, it will load and reuse the same window.

You can test this feature with the following similar example:

```
cat <(echo -n "537647 ") test.stl <(echo -n "7654 ") test2.stl | erizo -
```